### PR TITLE
test: cover execution completion timing

### DIFF
--- a/chain-processor-core/tests/unit/test_execution.py
+++ b/chain-processor-core/tests/unit/test_execution.py
@@ -1,0 +1,24 @@
+"""Unit tests for ChainExecution model."""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from chain_processor_core.models.execution import ChainExecution
+
+
+def test_chain_execution_completion_and_timing():
+    """ChainExecution should populate completion fields on validation."""
+    start = datetime.utcnow() - timedelta(milliseconds=10)
+    execution = ChainExecution(
+        strategy_id=uuid4(),
+        input_text="test",
+        status="success",
+        started_at=start,
+    )
+
+    # Re-validate to trigger execution_time_ms calculation
+    execution = ChainExecution.model_validate(execution.model_dump())
+
+    assert execution.completed_at is not None
+    assert execution.execution_time_ms is not None
+    assert execution.execution_time_ms >= 0


### PR DESCRIPTION
## Summary
- add tests for ChainExecution auto completion timing

## Testing
- `python -m pytest tests/unit/test_execution.py -vv` *(fails: No module named pytest)*