### PR TITLE
Add API endpoints and dockerized tests

### DIFF
--- a/chain-processor-api/Dockerfile
+++ b/chain-processor-api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+RUN pip install --no-cache-dir .
+
+COPY src/ src/
+
+CMD ["uvicorn", "chain_processor_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/chain-processor-api/Dockerfile.test
+++ b/chain-processor-api/Dockerfile.test
@@ -1,0 +1,25 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install PostgreSQL client for psycopg2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    python3-dev \
+    libpq-dev \
+    netcat-traditional \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install project with dev dependencies
+COPY pyproject.toml README.md ./
+RUN pip install --no-cache-dir .[dev] psycopg2-binary
+
+# Copy test files
+COPY tests/ tests/
+COPY src/ src/
+
+# Set Python path
+ENV PYTHONPATH=/app
+
+CMD ["pytest", "-xvs"]

--- a/chain-processor-api/Makefile
+++ b/chain-processor-api/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test test-docker
+
+test:
+pytest
+
+test-docker:
+./scripts/run_tests.sh

--- a/chain-processor-api/README.md
+++ b/chain-processor-api/README.md
@@ -1,0 +1,20 @@
+# Chain Processor API
+
+REST API service for the Chain Processing System.
+
+## Development Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -e .[dev]
+uvicorn chain_processor_api.main:app --reload
+```
+
+## Running Tests
+
+Use Docker to run tests in an isolated PostgreSQL environment:
+
+```bash
+make test-docker
+```

--- a/chain-processor-api/docker-compose.test.yml
+++ b/chain-processor-api/docker-compose.test.yml
@@ -1,0 +1,30 @@
+services:
+  postgres_test:
+    image: postgres:14-alpine
+    container_name: chain-processor-api-test-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: chain_processor_test
+    ports:
+      - "5433:5432"  # Using 5433 to avoid conflicts with potential local PostgreSQL
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d chain_processor_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    container_name: chain-processor-api-test
+    environment:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@postgres_test:5432/chain_processor_test
+      PYTHONPATH: /app
+    depends_on:
+      postgres_test:
+        condition: service_healthy
+    volumes:
+      - .:/app
+    command: pytest -xvs 

--- a/chain-processor-api/pyproject.toml
+++ b/chain-processor-api/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling>=1.19.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "chain-processor-api"
+version = "0.1.0"
+description = "REST API service for the Chain Processing System"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [{ name = "Chain Processor Team" }]
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.28.0",
+    "chain-processor-core==0.1.0",
+    "chain-processor-db==0.1.0",
+    "pydantic>=2.11.0",
+    "psycopg2-binary>=2.9.0",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.1",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.8.0",
+    "ruff>=0.1.5",
+    "black>=23.11.0",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py313"
+
+[tool.black]
+line-length = 88
+target-version = ["py313"]
+
+[tool.mypy]
+python_version = "3.13"
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+strict_optional = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+minversion = "7.4"
+testpaths = ["tests"]
+python_files = "test_*.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/chain_processor_api"]

--- a/chain-processor-api/scripts/run_tests.sh
+++ b/chain-processor-api/scripts/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Start PostgreSQL container for testing
+echo "Starting PostgreSQL container for testing..."
+docker compose -f docker-compose.test.yml up -d postgres_test
+
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL to be ready..."
+docker compose -f docker-compose.test.yml run --rm test bash -c "while ! nc -z postgres_test 5432; do sleep 1; done"
+
+# Run tests
+echo "Running tests..."
+docker compose -f docker-compose.test.yml run --rm test pytest "$@"
+
+# Cleanup
+echo "Cleaning up..."
+docker compose -f docker-compose.test.yml down
+
+echo "Test run completed!"

--- a/chain-processor-api/src/chain_processor_api/__init__.py
+++ b/chain-processor-api/src/chain_processor_api/__init__.py
@@ -1,0 +1,3 @@
+"""Chain Processor API package."""
+
+__version__ = "0.1.0"

--- a/chain-processor-api/src/chain_processor_api/api/chains.py
+++ b/chain-processor-api/src/chain_processor_api/api/chains.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from chain_processor_db.session import get_db
+from chain_processor_db.models.chain import ChainStrategy
+from chain_processor_db.repositories.chain_repo import ChainRepository
+
+from ..schemas import ChainCreate, ChainRead
+
+router = APIRouter(prefix="/chains", tags=["chains"])
+
+
+@router.post("/", response_model=ChainRead)
+def create_chain(chain_in: ChainCreate, db: Session = Depends(get_db)) -> ChainRead:
+    repo = ChainRepository(db)
+    chain = ChainStrategy(
+        name=chain_in.name,
+        description=chain_in.description,
+        is_active=True,
+        tags=chain_in.tags,
+    )
+    repo.create(chain)
+    return ChainRead(
+        id=chain.id,
+        name=chain.name,
+        description=chain.description,
+        tags=chain.tags,
+        version=chain.version,
+    )
+
+
+@router.get("/", response_model=List[ChainRead])
+def list_chains(db: Session = Depends(get_db)) -> List[ChainRead]:
+    repo = ChainRepository(db)
+    chains = repo.get_all()
+    return [
+        ChainRead(
+            id=c.id,
+            name=c.name,
+            description=c.description,
+            tags=c.tags,
+            version=c.version,
+        )
+        for c in chains
+    ]

--- a/chain-processor-api/src/chain_processor_api/api/router.py
+++ b/chain-processor-api/src/chain_processor_api/api/router.py
@@ -1,0 +1,16 @@
+"""API router for the Chain Processor API."""
+
+from fastapi import APIRouter
+
+from .chains import router as chains_router
+from .users import router as users_router
+
+router = APIRouter()
+router.include_router(chains_router)
+router.include_router(users_router)
+
+
+@router.get("/ping")
+async def ping() -> dict[str, str]:
+    """Simple ping endpoint for connectivity checks."""
+    return {"message": "pong"}

--- a/chain-processor-api/src/chain_processor_api/api/users.py
+++ b/chain-processor-api/src/chain_processor_api/api/users.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import hashlib
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from chain_processor_db.session import get_db
+from chain_processor_db.models.user import User
+from chain_processor_db.repositories.user_repo import UserRepository
+
+from ..schemas import UserCreate, UserRead
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("/", response_model=UserRead)
+def create_user(user_in: UserCreate, db: Session = Depends(get_db)) -> UserRead:
+    repo = UserRepository(db)
+    if repo.get_by_email(user_in.email):
+        raise HTTPException(status_code=400, detail="Email already registered")
+
+    password_hash = hashlib.sha256(user_in.password.encode()).hexdigest()
+    user = User(
+        email=user_in.email,
+        password_hash=password_hash,
+        full_name=user_in.full_name or "",
+        is_active=True,
+        is_superuser=False,
+        roles=user_in.roles,
+    )
+    repo.create(user)
+    return UserRead(
+        id=user.id,
+        email=user.email,
+        full_name=user.full_name,
+        roles=user.roles,
+        is_active=user.is_active,
+        version=user.version,
+    )
+
+
+@router.get("/", response_model=List[UserRead])
+def list_users(db: Session = Depends(get_db)) -> List[UserRead]:
+    repo = UserRepository(db)
+    users = repo.get_all()
+    return [
+        UserRead(
+            id=u.id,
+            email=u.email,
+            full_name=u.full_name,
+            roles=u.roles,
+            is_active=u.is_active,
+            version=u.version,
+        )
+        for u in users
+    ]

--- a/chain-processor-api/src/chain_processor_api/core/config.py
+++ b/chain-processor-api/src/chain_processor_api/core/config.py
@@ -1,0 +1,20 @@
+"""Application configuration using Pydantic settings."""
+
+from pydantic import BaseSettings
+from typing import List
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    DATABASE_URL: str = (
+        "postgresql://postgres:postgres@localhost:5432/chain_processor"
+    )
+    CORS_ORIGINS: List[str] = ["*"]
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+
+settings = Settings()

--- a/chain-processor-api/src/chain_processor_api/main.py
+++ b/chain-processor-api/src/chain_processor_api/main.py
@@ -1,0 +1,39 @@
+"""FastAPI application for the Chain Processor system."""
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from .api.router import api_router
+from .core.config import settings
+from chain_processor_core.exceptions.errors import ChainProcessorError
+
+app = FastAPI(
+    title="Chain Processor API",
+    description="API for the Chain Processor system",
+    version="1.2.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.CORS_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(api_router, prefix="/api")
+
+
+@app.exception_handler(ChainProcessorError)
+async def chain_processor_exception_handler(
+    request: Request, exc: ChainProcessorError
+) -> JSONResponse:
+    """Handle Chain Processor specific errors."""
+    return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
+@app.get("/health")
+async def health_check() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "healthy"}

--- a/chain-processor-api/src/chain_processor_api/schemas.py
+++ b/chain-processor-api/src/chain_processor_api/schemas.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+    full_name: Optional[str] = None
+    roles: List[str] = []
+
+
+class UserRead(BaseModel):
+    id: UUID
+    email: EmailStr
+    full_name: Optional[str] = None
+    roles: List[str] = []
+    is_active: bool
+    version: int
+
+
+class ChainCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    tags: List[str] = []
+
+
+class ChainRead(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    tags: List[str] = []
+    version: int

--- a/chain-processor-api/tests/conftest.py
+++ b/chain-processor-api/tests/conftest.py
@@ -1,0 +1,167 @@
+"""
+Pytest configuration for Chain Processor DB tests.
+
+This module provides fixtures for testing database operations.
+"""
+
+import os
+import uuid
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+from chain_processor_db.base import metadata
+from chain_processor_db.models import *  # Import all models
+
+
+@pytest.fixture(scope="session")
+def db_url() -> str:
+    """Get the database URL for testing."""
+    test_db_url = os.environ.get(
+        "TEST_DATABASE_URL",
+        "postgresql://postgres:postgres@localhost:5432/chain_processor_test"
+    )
+    return test_db_url
+
+
+@pytest.fixture(scope="session")
+def engine(db_url: str):
+    """Create a database engine for testing."""
+    engine = create_engine(db_url)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def setup_db(engine):
+    """Set up the database for testing."""
+    # Create all tables
+    metadata.create_all(engine)
+    yield
+    # Drop all tables
+    metadata.drop_all(engine)
+
+
+@pytest.fixture(scope="function")
+def db_session(setup_db, engine) -> Generator[Session, None, None]:
+    """Create a database session for testing."""
+    connection = engine.connect()
+    transaction = connection.begin()
+    session_factory = sessionmaker(bind=connection)
+    session = session_factory()
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture
+def sample_user(db_session: Session):
+    """Create a sample user for testing."""
+    from chain_processor_db.models.user import User
+    
+    user = User(
+        email="test@example.com",
+        password_hash="hashed_password",
+        full_name="Test User",
+        is_active=True,
+        is_superuser=False,
+        roles=["user"],
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def sample_node(db_session: Session, sample_user):
+    """Create a sample node for testing."""
+    from chain_processor_db.models.node import Node
+    
+    node = Node(
+        name="Test Node",
+        description="A test node",
+        code="def node(input_text): return input_text.upper()",
+        created_by_id=sample_user.id,
+        is_builtin=False,
+        is_active=True,
+        tags=["test", "uppercase"],
+    )
+    db_session.add(node)
+    db_session.commit()
+    db_session.refresh(node)
+    return node
+
+
+@pytest.fixture
+def sample_strategy(db_session: Session, sample_user):
+    """Create a sample chain strategy for testing."""
+    from chain_processor_db.models.chain import ChainStrategy
+    
+    strategy = ChainStrategy(
+        name="Test Strategy",
+        description="A test strategy",
+        created_by_id=sample_user.id,
+        is_active=True,
+        tags=["test"],
+    )
+    db_session.add(strategy)
+    db_session.commit()
+    db_session.refresh(strategy)
+    return strategy
+
+
+@pytest.fixture
+def sample_strategy_node(db_session: Session, sample_strategy, sample_node):
+    """Create a sample strategy node link for testing."""
+    from chain_processor_db.models.chain import StrategyNode
+    
+    strategy_node = StrategyNode(
+        strategy_id=sample_strategy.id,
+        node_id=sample_node.id,
+        position=0,
+        config={},
+    )
+    db_session.add(strategy_node)
+    db_session.commit()
+    db_session.refresh(strategy_node)
+    return strategy_node
+
+
+@pytest.fixture
+def sample_chain_execution(db_session: Session, sample_strategy, sample_user):
+    """Create a sample chain execution for testing."""
+    from chain_processor_db.models.execution import ChainExecution
+    
+    execution = ChainExecution(
+        strategy_id=sample_strategy.id,
+        input_text="test input",
+        status="pending",
+        created_by_id=sample_user.id,
+    )
+    db_session.add(execution)
+    db_session.commit()
+    db_session.refresh(execution)
+    return execution
+
+
+@pytest.fixture
+def sample_node_execution(db_session: Session, sample_chain_execution, sample_node):
+    """Create a sample node execution for testing."""
+    from chain_processor_db.models.execution import NodeExecution
+    
+    node_execution = NodeExecution(
+        execution_id=sample_chain_execution.id,
+        node_id=sample_node.id,
+        input_text="test input",
+        status="pending",
+    )
+    db_session.add(node_execution)
+    db_session.commit()
+    db_session.refresh(node_execution)
+    return node_execution 

--- a/chain-processor-api/tests/unit/test_chains.py
+++ b/chain-processor-api/tests/unit/test_chains.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from chain_processor_api.main import app
+from chain_processor_db.session import get_db
+
+
+def test_create_chain(db_session: Session):
+    def override_db():
+        yield db_session
+    app.dependency_overrides[get_db] = override_db
+
+    client = TestClient(app)
+    payload = {"name": "Test Chain"}
+    response = client.post("/api/chains/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Test Chain"
+    app.dependency_overrides.clear()

--- a/chain-processor-api/tests/unit/test_health.py
+++ b/chain-processor-api/tests/unit/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from chain_processor_api.main import app
+
+
+def test_health_check():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}

--- a/chain-processor-api/tests/unit/test_users.py
+++ b/chain-processor-api/tests/unit/test_users.py
@@ -1,0 +1,20 @@
+import json
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from chain_processor_api.main import app
+from chain_processor_db.session import get_db
+
+
+def test_create_user(db_session: Session):
+    def override_db():
+        yield db_session
+    app.dependency_overrides[get_db] = override_db
+
+    client = TestClient(app)
+    payload = {"email": "u@example.com", "password": "Secretpass1"}
+    response = client.post("/api/users/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "u@example.com"
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- expand API router to include chain and user routes
- implement `/chains` and `/users` endpoints
- provide pydantic schemas for API objects
- add Docker-based test tooling and sample tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ❌ `python -m pytest -q` *(pytest missing)*