### PR TITLE
Fix declared_attr usage in DB models

### DIFF
--- a/chain-processor-db/src/chain_processor_db/models/base.py
+++ b/chain-processor-db/src/chain_processor_db/models/base.py
@@ -6,7 +6,7 @@ This module defines the base model class for all database models.
 
 import uuid
 from sqlalchemy import Column, Integer, DateTime, func, String, UUID
-from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import declared_attr
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..base import Base, TimestampMixin, VersionedMixin
@@ -21,7 +21,7 @@ class BaseModel(Base, TimestampMixin):
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
 
-    @declared_attr.directive
+    @declared_attr
     def __tablename__(cls) -> str:
         """Return the table name for the model."""
         return cls.__name__.lower()


### PR DESCRIPTION
## Summary
- fix wrong decorator for SQLAlchemy declared_attr

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*