### PR TITLE
Fix config imports and add repo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python cache and packaging
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+.eggs/
+*.egg-info/
+
+# Virtual environments
+venv/
+.env
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.tox/
+.pytest_cache/
+.coverage
+htmlcov/

--- a/chain-processor-api/src/chain_processor_api/core/config.py
+++ b/chain-processor-api/src/chain_processor_api/core/config.py
@@ -1,9 +1,8 @@
 """Application configuration using Pydantic settings."""
 
-from typing import List, Union
+from typing import List
 
 from pydantic_settings import BaseSettings
-from pydantic import AnyHttpUrl
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- clean up unused Pydantic imports
- add a root `.gitignore` with common Python ignores

## Testing
- `ruff check chain-processor-api/src/chain_processor_api/core/config.py`