### PR TITLE
Fix reserved SQLAlchemy metadata attribute

### DIFF
--- a/chain-processor-db/docs/schema/database_schema.md
+++ b/chain-processor-db/docs/schema/database_schema.md
@@ -1,6 +1,9 @@
 # Chain Processor DB - Database Schema
 
 This document describes the database schema for the Chain Processing System.
+ORM models expose JSONB columns named `metadata` using the attribute
+`metadata_json` to avoid conflicts with SQLAlchemy's reserved `metadata`
+attribute.
 
 ## Entity Relationship Diagram
 

--- a/chain-processor-db/src/chain_processor_db/models/chain.py
+++ b/chain-processor-db/src/chain_processor_db/models/chain.py
@@ -26,7 +26,9 @@ class ChainStrategy(BaseVersionedModel):
     )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     tags: Mapped[List[str]] = mapped_column(ARRAY(String), default=list, nullable=False)
-    metadata: Mapped[Dict] = mapped_column(JSONB, default=dict, nullable=False)
+    metadata_json: Mapped[Dict] = mapped_column(
+        "metadata", JSONB, default=dict, nullable=False
+    )
 
     # Relationships
     created_by_user = relationship("User", back_populates="chain_strategies")

--- a/chain-processor-db/src/chain_processor_db/models/execution.py
+++ b/chain-processor-db/src/chain_processor_db/models/execution.py
@@ -46,7 +46,9 @@ class ChainExecution(BaseVersionedModel):
     created_by_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         ForeignKey("users.id"), nullable=True
     )
-    metadata: Mapped[Dict] = mapped_column(JSONB, default=dict, nullable=False)
+    metadata_json: Mapped[Dict] = mapped_column(
+        "metadata", JSONB, default=dict, nullable=False
+    )
 
     # Relationships
     strategy = relationship("ChainStrategy", back_populates="chain_executions")
@@ -84,7 +86,9 @@ class NodeExecution(BaseModel):
     started_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, nullable=False)
     completed_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
     execution_time_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    metadata: Mapped[Dict] = mapped_column(JSONB, default=dict, nullable=False)
+    metadata_json: Mapped[Dict] = mapped_column(
+        "metadata", JSONB, default=dict, nullable=False
+    )
 
     # Relationships
     chain_execution = relationship("ChainExecution", back_populates="node_executions")

--- a/chain-processor-db/src/chain_processor_db/models/node.py
+++ b/chain-processor-db/src/chain_processor_db/models/node.py
@@ -27,7 +27,9 @@ class Node(BaseVersionedModel):
     )
     is_builtin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
-    metadata: Mapped[Dict] = mapped_column(JSONB, default=dict, nullable=False)
+    metadata_json: Mapped[Dict] = mapped_column(
+        "metadata", JSONB, default=dict, nullable=False
+    )
     tags: Mapped[List[str]] = mapped_column(ARRAY(String), default=list, nullable=False)
 
     # Relationships


### PR DESCRIPTION
## Summary
- fix InvalidRequestError by renaming reserved `metadata` ORM fields
- document the `metadata_json` attribute convention

## Testing
- `pip install -e chain-processor-db[dev]` *(fails: Could not find a version that satisfies the requirement)*
- `python -m pytest chain-processor-db/tests` *(fails: No module named pytest)*