### PR TITLE
Fix Alembic import error

### DIFF
--- a/chain-processor-db/src/chain_processor_db/base.py
+++ b/chain-processor-db/src/chain_processor_db/base.py
@@ -28,6 +28,9 @@ convention = {
 # Create metadata with naming conventions
 chain_db_metadata = MetaData(naming_convention=convention)
 
+# Export metadata for backwards compatibility with Alembic environment
+metadata = chain_db_metadata
+
 
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy models."""


### PR DESCRIPTION
## Summary
- expose `metadata` variable from the DB base module so Alembic can import it

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*